### PR TITLE
Update settings.dart to change deprecated child method to builder method

### DIFF
--- a/lib/interfaces/settings.dart
+++ b/lib/interfaces/settings.dart
@@ -115,7 +115,7 @@ class _ThemeSettingCardState extends State<ThemeSettingCard> {
           onTap: (){
             showDialog(
                 context: context,
-                child: SimpleDialog(
+                builder: (_) => new SimpleDialog(
                   title: Text("Choose theme..."),
                   children: <Widget>[
                     RadioListTile<ThemeOptions>(
@@ -283,7 +283,7 @@ class _ClearDataCardState extends State<ClearDataCard> {
           onTap: (){
             showDialog(
                 context: context,
-                child: SimpleDialog(
+                builder: (_) => new SimpleDialog(
                   title: Text("Delete old feeds"),
                   children: <Widget>[
                     SimpleDialogOption(


### PR DESCRIPTION
The child method is deprecated, changed it to the new builder method.
https://stackoverflow.com/questions/50144356/showdialog-using-children-is-deprecated-how-to-use-it-the-other-way/50144478